### PR TITLE
Skin the error labels

### DIFF
--- a/semanticuiform/templates/semanticui/field.html
+++ b/semanticuiform/templates/semanticui/field.html
@@ -34,7 +34,7 @@
             {% endfor %}
 
             {% for error in field.errors %}
-                <span class="label {{ form.error_css_class }}">{{ error }}</span>
+                <span class="ui pointing red basic label {{ form.error_css_class }}">{{ error }}</span>
             {% endfor %}
 
             {% if field.help_text %}
@@ -53,7 +53,7 @@
             {{ field }}
 
             {% for error in field.errors %}
-                <span class="label {{ form.error_css_class }}">{{ error }}</span>
+                <span class="ui pointing red basic label {{ form.error_css_class }}">{{ error }}</span>
             {% endfor %}
 
             {% if field.help_text %}


### PR DESCRIPTION
This does not leave the error labels so bare. Uses the pointing error label:

http://semantic-ui.com/elements/label.html#pointing
